### PR TITLE
[F] Add saveAnswersFromSet mutation

### DIFF
--- a/api/modules/investigations/gql/interfaces/elements/Answer.php
+++ b/api/modules/investigations/gql/interfaces/elements/Answer.php
@@ -39,17 +39,17 @@ class Answer extends Element
             [
                 'userId' => [
                     'name' => 'userId',
-                    'type' => Type::int(),
+                    'type' => Type::id(),
                     'description' => 'ID of the user answering the question'
                 ],
                 'questionId' => [
                     'name' => 'questionId',
-                    'type' => Type::int(),
+                    'type' => Type::id(),
                     'description' => 'ID of the question being answered'
                 ],
                 'investigationId' => [
                     'name' => 'investigationId',
-                    'type' => Type::int(),
+                    'type' => Type::id(),
                     'description' => 'ID of the Investigation parent'
                 ],
                 'data' => [

--- a/api/modules/investigations/gql/mutations/Answer.php
+++ b/api/modules/investigations/gql/mutations/Answer.php
@@ -7,6 +7,7 @@ use GraphQL\Type\Definition\Type;
 use modules\investigations\gql\helpers\Gql as GqlHelper;
 use modules\investigations\gql\resolvers\mutations\Answer as AnswerMutationResolver;
 use modules\investigations\gql\interfaces\elements\Answer as AnswerInterface;
+use modules\investigations\gql\types\input\Answer as AnswerInput;
 
 class Answer extends Mutation
 {
@@ -42,6 +43,18 @@ class Answer extends Mutation
             'resolve' => [$resolver, 'saveAnswer'],
             'description' => 'Saves an existing answer',
             'type' => AnswerInterface::getType()
+        ];
+
+        $mutations['saveAnswersFromSet'] = [
+            'name' => 'saveAnswersFromSet',
+            'args' => [
+                'userId' => Type::nonNull(Type::int()),
+                'investigationId' => Type::nonNull(Type::int()),
+                'answerSet' => Type::listOf(AnswerInput::getType())
+            ],
+            'resolve' => [$resolver, 'saveAnswersFromSet'],
+            'description' => 'Saves a set of answers',
+            'type' => Type::listOf(AnswerInterface::getType())
         ];
 
         return $mutations;

--- a/api/modules/investigations/gql/mutations/Answer.php
+++ b/api/modules/investigations/gql/mutations/Answer.php
@@ -24,9 +24,9 @@ class Answer extends Mutation
         $mutations['createAnswer'] = [
             'name' => 'createAnswer',
             'args' => [
-                'userId' => Type::nonNull(Type::int()),
-                'questionId' => Type::nonNull(Type::int()),
-                'investigationId' => Type::nonNull(Type::int()),
+                'userId' => Type::nonNull(Type::id()),
+                'questionId' => Type::nonNull(Type::id()),
+                'investigationId' => Type::nonNull(Type::id()),
                 'data' => Type::string()
             ],
             'resolve' => [$resolver, 'saveAnswer'],
@@ -37,7 +37,7 @@ class Answer extends Mutation
         $mutations['saveAnswer'] = [
             'name' => 'saveAnswer',
             'args' => [
-                'id' => Type::nonNull(Type::int()),
+                'id' => Type::nonNull(Type::id()),
                 'data' => Type::string()
             ],
             'resolve' => [$resolver, 'saveAnswer'],
@@ -48,8 +48,8 @@ class Answer extends Mutation
         $mutations['saveAnswersFromSet'] = [
             'name' => 'saveAnswersFromSet',
             'args' => [
-                'userId' => Type::nonNull(Type::int()),
-                'investigationId' => Type::nonNull(Type::int()),
+                'userId' => Type::nonNull(Type::id()),
+                'investigationId' => Type::nonNull(Type::id()),
                 'answerSet' => Type::listOf(AnswerInput::getType())
             ],
             'resolve' => [$resolver, 'saveAnswersFromSet'],

--- a/api/modules/investigations/gql/resolvers/mutations/Answer.php
+++ b/api/modules/investigations/gql/resolvers/mutations/Answer.php
@@ -2,6 +2,7 @@
 
 namespace modules\investigations\gql\resolvers\mutations;
 
+use Craft;
 use craft\gql\base\ElementMutationResolver;
 use GraphQL\Error\UserError;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -35,5 +36,20 @@ class Answer extends ElementMutationResolver
         }
 
         return $elementService->getElementById($answer->id, AnswerElement::class);
+    }
+
+    public function saveAnswersFromSet($source, array $arguments, $context, ResolveInfo $resolveInfo)
+    {
+        $elements = [];
+        foreach($arguments['answerSet'] as $answer) {
+            $resolverArgs = ['userId' => $arguments['userId'], 'investigationId' => $arguments['investigationId']];
+            foreach($answer as $key => $attribute) {
+                $resolverArgs[$key] = $attribute;
+            }
+
+            $elements[] = $this->saveAnswer($source, $resolverArgs, $context, $resolveInfo);
+        }
+
+        return $elements;
     }
 }

--- a/api/modules/investigations/gql/types/input/Answer.php
+++ b/api/modules/investigations/gql/types/input/Answer.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace modules\investigations\gql\types\input;
+
+use craft\gql\GqlEntityRegistry;
+use GraphQL\Type\Definition\InputObjectType;
+use GraphQL\Type\Definition\Type;
+
+class Answer extends InputObjectType
+{
+    /**
+     * @return mixed
+     */
+    public static function getType(): mixed
+    {
+        $typeName = 'AnswerInput';
+
+        return GqlEntityRegistry::getOrCreate($typeName, fn() => new InputObjectType([
+            'name' => $typeName,
+            'fields' => [
+                'id' => [
+                    'name' => 'id',
+                    'type' => Type::int(),
+                    'description' => 'The ID of the Answer element, if it exists.',
+                ],
+                'questionId' => [
+                    'name' => 'questionId',
+                    'type' => Type::int(),
+                    'description' => 'The ID of the associated Question entry.',
+                ],
+                'data' => [
+                    'name' => 'data',
+                    'type' => Type::string(),
+                    'description' => 'The data submitted by the user.',
+                ],
+            ],
+        ]));
+    }
+}

--- a/api/modules/investigations/gql/types/input/Answer.php
+++ b/api/modules/investigations/gql/types/input/Answer.php
@@ -20,12 +20,12 @@ class Answer extends InputObjectType
             'fields' => [
                 'id' => [
                     'name' => 'id',
-                    'type' => Type::int(),
+                    'type' => Type::id(),
                     'description' => 'The ID of the Answer element, if it exists.',
                 ],
                 'questionId' => [
                     'name' => 'questionId',
-                    'type' => Type::int(),
+                    'type' => Type::id(),
                     'description' => 'The ID of the associated Question entry.',
                 ],
                 'data' => [


### PR DESCRIPTION
@dananjohnson I think this is now ready for testing! Rather than just passing the json directly, I created an `answerInput` GQL input type, which in turn allows us to more strongly type the data going in (`id` is an int, `data` is a string, etc.). 

Here's an example of a successful mutation from GraphiQL:
```
mutation saveAnswerSet {
  saveAnswersFromSet(
    investigationId: 10
    userId: 10
    answerSet: [{data: "option-1", questionId: 713}, {data: "option-2", questionId: 727}, {data: "Test answer121212", questionId: 745, id: 1611}, {data: "test", questionId: 747}]
  ) {
    id
    data
    investigationId
    userId
  }
}
```