### PR TITLE
[B] PublicRegistration enabled & publicSchema viewable users narrowed

### DIFF
--- a/api/config/project/graphql/schemas/cec04a25-43ba-4f4c-81bd-b71f48731b5a.yaml
+++ b/api/config/project/graphql/schemas/cec04a25-43ba-4f4c-81bd-b71f48731b5a.yaml
@@ -25,5 +25,6 @@ scope:
   - 'volumes.7a4c811e-eb74-4c4b-ae64-134f2a4e2c3e:read' # Datasets
   - 'globalsets.aee57b4f-2623-44fc-af2b-c670f6e1babe:read' # Site information
   - 'globalsets.0edce3a2-c596-4238-9dde-212c83d5a65f:read' # Menu Content
-  - 'usergroups.everyone:read'
+  - 'usergroups.d8be03ce-7aeb-4141-b40e-ec39ec1c796f:read' # Educators
+  - 'usergroups.461e1254-37f7-4aeb-81a1-3f08d2463d06:read' # Students
   - 'categorygroups.90aa9610-a9c9-4531-95f8-d0068046ae25:read' # Sort Options

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1708626550
+dateModified: 1709252018
 elementSources:
   craft\elements\Entry:
     -

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1709252018
+dateModified: 1709590312
 elementSources:
   craft\elements\Entry:
     -

--- a/api/config/project/users/users.yaml
+++ b/api/config/project/users/users.yaml
@@ -1,6 +1,6 @@
 allowPublicRegistration: true
 deactivateByDefault: false
-defaultGroup: ''
+defaultGroup: 461e1254-37f7-4aeb-81a1-3f08d2463d06 # Students
 photoSubpath: null
 photoVolumeUid: null
 requireEmailVerification: true

--- a/api/config/project/users/users.yaml
+++ b/api/config/project/users/users.yaml
@@ -1,6 +1,7 @@
-allowPublicRegistration: false
+allowPublicRegistration: true
 deactivateByDefault: false
-defaultGroup: null
+defaultGroup: ''
 photoSubpath: null
 photoVolumeUid: null
 requireEmailVerification: true
+validateOnPublicRegistration: false


### PR DESCRIPTION
Changes made:
 - publicRegistration seems to maybe be needed in some cases to allow Oauth registration
 - public graphql schema only needs to view educator and student groups

Notes for Reviewers:
In truth, I am not confident these changes were actually needed on the backend to see Google Auth successfully, but these changes do bring the CMS/gql-auth plugin setup more in line with `rubin-apo-api` setup, so we'll roll with it for now.
Test alongside [#143](https://github.com/lsst-epo/investigations-client/pull/143)