### PR TITLE
[C] disallow translations of option values

### DIFF
--- a/api/config/project/matrixBlockTypes/option--dd3a1151-8de9-46f6-995f-c721fa29a07b.yaml
+++ b/api/config/project/matrixBlockTypes/option--dd3a1151-8de9-46f6-995f-c721fa29a07b.yaml
@@ -10,7 +10,7 @@ fieldLayouts:
             fieldUid: 34ce437a-0ab5-47b3-8894-ff749aee20e9 # Option Value
             instructions: null
             label: null
-            required: false
+            required: true
             tip: null
             type: craft\fieldlayoutelements\CustomField
             uid: 43220c27-dd17-458d-bb19-4039551c908f
@@ -38,27 +38,27 @@ fields:
     contentColumnType: text
     fieldGroup: null
     handle: optionValue
-    instructions: null
+    instructions: 'Unique key for system to use, not visible to users.'
     name: 'Option Value'
     searchable: false
     settings:
       byteLimit: null
       charLimit: null
-      code: false
+      code: true
       columnType: null
       initialRows: 4
       multiline: false
       placeholder: null
       uiMode: normal
     translationKeyFormat: null
-    translationMethod: site
+    translationMethod: none
     type: craft\fields\PlainText
   ff6964ee-dc07-4a6c-a911-14f43c581d0f: # Option Label
     columnSuffix: zkreover
     contentColumnType: text
     fieldGroup: null
     handle: optionLabel
-    instructions: null
+    instructions: 'Display text visible to users'
     name: 'Option Label'
     searchable: false
     settings:

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1713468765
+dateModified: 1713477663
 elementSources:
   craft\elements\Entry:
     -


### PR DESCRIPTION
Disallow translating option values so that answers are always keyed to a non-changing value.

ex. if translation is allowed then a value-label pair may look like:

EN:
```javascript
{ value: "red", label: "Red" }
```

ES:
```javascript
{ value: "roja", label: "Roja" }
```

in this case if a user starts in English, answers the question, and switches to Spanish, the client will try to look up the selected option using "red" and not find it.

the desired result should be

EN:
```javascript
{ value: "red", label: "Red" }
```

ES:
```javascript
{ value: "red", label: "Roja" }
```

This change will lose stored answers for primarily non-English users, if the option values were translated previously.

An even more ideal setup would probably be to do away with `value` entirely, and use the `id` of the matrix item as it's lookup key, this would lose all select answers for all users 