### PR TITLE
[C] make alert source name required

### DIFF
--- a/api/config/project/matrixBlockTypes/source--af7d475a-5acc-4523-9acf-257ac909e7ec.yaml
+++ b/api/config/project/matrixBlockTypes/source--af7d475a-5acc-4523-9acf-257ac909e7ec.yaml
@@ -22,7 +22,7 @@ fieldLayouts:
             fieldUid: 4941158b-702a-45b4-8da5-12ed4202efae # Name
             instructions: null
             label: null
-            required: false
+            required: true
             tip: null
             type: craft\fieldlayoutelements\CustomField
             uid: 62113937-c37c-45b7-9a7e-eb13a42f43dc
@@ -162,7 +162,7 @@ fields:
     settings:
       byteLimit: null
       charLimit: null
-      code: false
+      code: true
       columnType: null
       initialRows: 4
       multiline: false

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1714427968
+dateModified: 1715193932
 elementSources:
   craft\elements\Entry:
     -


### PR DESCRIPTION
Make source name required since it is necessary for source selector to perform callbacks correctly.

Resolves #113 