### PR TITLE
feat: add sortable table fields and related configurations

### DIFF
--- a/api/config/project/entryTypes/sortableTable--16d66db4-47e3-4e22-a040-357377f43cb0.yaml
+++ b/api/config/project/entryTypes/sortableTable--16d66db4-47e3-4e22-a040-357377f43cb0.yaml
@@ -1,0 +1,69 @@
+fieldLayouts:
+  f36eac86-b105-4069-8d58-ffc0f75df690:
+    tabs:
+      -
+        elementCondition: null
+        elements:
+          -
+            autocapitalize: true
+            autocomplete: false
+            autocorrect: true
+            class: null
+            disabled: false
+            elementCondition: null
+            id: null
+            inputType: null
+            instructions: null
+            label: null
+            max: null
+            min: null
+            name: null
+            orientation: null
+            placeholder: null
+            readonly: false
+            requirable: false
+            size: null
+            step: null
+            tip: null
+            title: null
+            type: craft\fieldlayoutelements\entries\EntryTitleField
+            uid: be96be44-8356-4939-8de9-ad492dafa366
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition:
+              class: craft\elements\conditions\entries\EntryCondition
+              conditionRules:
+                -
+                  class: craft\elements\conditions\entries\TypeConditionRule
+                  operator: in
+                  uid: aaae784c-03d3-4330-bb68-cd223dd56cd7
+                  values:
+                    - 16d66db4-47e3-4e22-a040-357377f43cb0 # Sortable Table
+              elementType: craft\elements\Entry
+              fieldContext: global
+            fieldUid: a4afde15-f983-4c30-b0d7-e0b56871e4de # Dataset
+            instructions: null
+            label: 'Sortable Table Dataset'
+            required: true
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 8ee0878e-3fd8-4b8b-bad6-456749fc504c
+            userCondition: null
+            warning: null
+            width: 100
+        name: Content
+        uid: b892cc99-c162-4e2d-96c5-656cc5c52c7c
+        userCondition: null
+handle: sortableTable
+hasTitleField: true
+name: 'Sortable Table'
+section: 28704998-935a-423b-a405-d4ad8b38efa2 # Widgets
+showStatusField: true
+slugTranslationKeyFormat: null
+slugTranslationMethod: site
+sortOrder: 6
+titleFormat: null
+titleTranslationKeyFormat: null
+titleTranslationMethod: site

--- a/api/config/project/entryTypes/sortableTableData--75b9158d-af71-42ce-8daa-5a026215d2a9.yaml
+++ b/api/config/project/entryTypes/sortableTableData--75b9158d-af71-42ce-8daa-5a026215d2a9.yaml
@@ -1,0 +1,59 @@
+fieldLayouts:
+  28de6078-1b26-47e9-a583-f800e169718b:
+    tabs:
+      -
+        elementCondition: null
+        elements:
+          -
+            autocapitalize: true
+            autocomplete: false
+            autocorrect: true
+            class: null
+            disabled: false
+            elementCondition: null
+            id: null
+            inputType: null
+            instructions: null
+            label: null
+            max: null
+            min: null
+            name: null
+            orientation: null
+            placeholder: null
+            readonly: false
+            requirable: false
+            size: null
+            step: null
+            tip: null
+            title: null
+            type: craft\fieldlayoutelements\entries\EntryTitleField
+            uid: bfa621f3-5fb9-4016-b1cc-14e8d2b7a20f
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
+            fieldUid: a03e80f0-77ce-4b03-abf5-76a0deb264a9 # JSON
+            instructions: null
+            label: 'Table Data'
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: e9cfeab1-8ab3-4866-87f7-127103495fd1
+            userCondition: null
+            warning: null
+            width: 100
+        name: Content
+        uid: d4d83f55-84d2-4fd5-ab39-f58e26d7ba20
+        userCondition: null
+handle: sortableTableData
+hasTitleField: true
+name: 'Sortable Table Data'
+section: fbfbf05d-c7e1-4f6c-a093-47065f8d5095 # Datasets
+showStatusField: true
+slugTranslationKeyFormat: null
+slugTranslationMethod: site
+sortOrder: 4
+titleFormat: null
+titleTranslationKeyFormat: null
+titleTranslationMethod: site

--- a/api/config/project/fields/sortableTableWidget--16f93737-90e2-4533-8417-be6eacbe389b.yaml
+++ b/api/config/project/fields/sortableTableWidget--16f93737-90e2-4533-8417-be6eacbe389b.yaml
@@ -1,0 +1,53 @@
+columnSuffix: null
+contentColumnType: string
+fieldGroup: a21a42b0-7211-4d77-9071-47a06960fef4 # Widgets
+handle: sortableTableWidget
+instructions: null
+name: 'Sortable Table Widget'
+searchable: false
+settings:
+  allowSelfRelations: false
+  branchLimit: null
+  localizeRelations: false
+  maintainHierarchy: false
+  maxRelations: null
+  minRelations: null
+  selectionCondition:
+    __assoc__:
+      -
+        - elementType
+        - craft\elements\Entry
+      -
+        - fieldContext
+        - global
+      -
+        - class
+        - craft\elements\conditions\entries\EntryCondition
+      -
+        - conditionRules
+        -
+          -
+            __assoc__:
+              -
+                - class
+                - craft\elements\conditions\entries\TypeConditionRule
+              -
+                - uid
+                - 0c0f0933-1650-4d1f-825f-25977170a10e
+              -
+                - operator
+                - in
+              -
+                - values
+                -
+                  - 16d66db4-47e3-4e22-a040-357377f43cb0 # Sortable Table
+  selectionLabel: null
+  showSiteMenu: false
+  sources:
+    - 'section:28704998-935a-423b-a405-d4ad8b38efa2' # Widgets
+  targetSiteId: null
+  validateRelatedElements: false
+  viewMode: null
+translationKeyFormat: null
+translationMethod: site
+type: craft\fields\Entries

--- a/api/config/project/neo/orders/a46e7379-7773-4ce4-9c59-434567870f0c.yaml
+++ b/api/config/project/neo/orders/a46e7379-7773-4ce4-9c59-434567870f0c.yaml
@@ -27,3 +27,4 @@
 - 'blockType:002018ff-41ee-4347-88a0-c2c63efee1b2' # CTA Grid
 - 'blockType:325b9f09-b0da-44b6-9cd7-885d7a29e53c' # CTA
 - 'blockType:5f056533-e53a-476a-9e3b-14e2aa364517' # Orbital Sim Widget
+- 'blockType:1323f40e-55e0-4e0d-a8d8-94f30957cf94' # Sortable Table Block

--- a/api/config/project/neoBlockTypes/sortableTable--1323f40e-55e0-4e0d-a8d8-94f30957cf94.yaml
+++ b/api/config/project/neoBlockTypes/sortableTable--1323f40e-55e0-4e0d-a8d8-94f30957cf94.yaml
@@ -1,0 +1,40 @@
+childBlocks: null
+conditions: null
+description: ''
+enabled: true
+field: a46e7379-7773-4ce4-9c59-434567870f0c # Content Blocks
+fieldLayouts:
+  9694880b-e0d9-4918-b4ec-c7c59ce6ac29:
+    tabs:
+      -
+        elementCondition: null
+        elements:
+          -
+            elementCondition: null
+            fieldUid: 16f93737-90e2-4533-8417-be6eacbe389b # Sortable Table Widget
+            instructions: null
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 3034c9f1-fb00-490b-bedd-ac33458d6433
+            userCondition: null
+            warning: null
+            width: 100
+        name: Widget
+        uid: 457de095-445e-4ab7-9242-e048cc6c8df6
+        userCondition: null
+group: 513634e9-3389-4e41-b769-9433ac34e35e # Widgets
+groupChildBlockTypes: true
+handle: sortableTable
+icon: null
+iconFilename: ''
+ignorePermissions: true
+maxBlocks: 0
+maxChildBlocks: 0
+maxSiblingBlocks: 0
+minBlocks: 0
+minChildBlocks: 0
+minSiblingBlocks: 0
+name: 'Sortable Table Block'
+topLevel: true

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1775681894
+dateModified: 1776816997
 elementSources:
   craft\elements\Entry:
     -
@@ -201,6 +201,8 @@ meta:
     10bfe164-c055-47a5-9acf-414d5c53b74a: 'X-axis Maximum' # X-axis Maximum
     010dc3f6-c369-4937-adc7-1948204aaf97: Group # Group
     11f12958-c08d-4f26-9466-1a8ba7011b34: 'Camera Filter Tool' # Camera Filter Tool
+    16d66db4-47e3-4e22-a040-357377f43cb0: 'Sortable Table' # Sortable Table
+    16f93737-90e2-4533-8417-be6eacbe389b: 'Sortable Table Widget' # Sortable Table Widget
     17b9b8a2-978a-4cd8-a7da-f5b3d77e1ed3: 'Graph Bars' # Graph Bars
     20ce6c99-37f5-4f50-91fa-587e9f7ef466: Comparison # Comparison
     021f7cc6-93ec-4da4-9566-8d05c64d1725: Default # Default
@@ -232,6 +234,7 @@ meta:
     71b3bf66-70f5-4af6-8020-aab77b765608: Video # Video
     74a879e6-ccb0-40d1-81b8-1906678d0219: 'Row Title' # Row Title
     074f7db9-8ff3-4016-ad34-bfe9c31d5543: Pages # Pages
+    75b9158d-af71-42ce-8daa-5a026215d2a9: 'Sortable Table Data' # Sortable Table Data
     77f02908-0342-4917-9d14-38f769d15c39: Pages # Pages
     79f2f742-966c-42df-9d04-8492d456325c: Minimum # Minimum
     87fc48a5-a399-4ce1-a7ca-2dadfd1e1445: 'Camera Filter Tool' # Camera Filter Tool
@@ -263,6 +266,7 @@ meta:
     919ed98f-d33e-4fae-adc0-2253a155246f: 'Question Text' # Question Text
     986be506-1a98-4a56-9a16-1e2270071a95: isActive # isActive
     997d2cc5-340b-48d0-9f44-032b2c6ec179: 'Previous Question' # Previous Question
+    1323f40e-55e0-4e0d-a8d8-94f30957cf94: 'Sortable Table Block' # Sortable Table Block
     1601c7a8-2437-4b8f-b2f2-116f4c043402: 'Site Information' # Site Information
     002018ff-41ee-4347-88a0-c2c63efee1b2: 'CTA Grid' # CTA Grid
     2297d098-675f-4def-bd51-0ce739720cdc: 'Simple Table' # Simple Table


### PR DESCRIPTION
Resolves #192 

Created the following:
- SortableTableData, for adding table row content in JSON format
- SortableTable, a Widget entry type with fields specific to the Sortable Table
- SortableTableWidget, to enable filtering on Widget entry types
- SortableTableBlock, to add the Sortable Table to a page as a regular content block