### PR TITLE
feat: add "Has Moving Source" lightswitch field to Source Selector entry form

### DIFF
--- a/api/config/project/entryTypes/sourceSelector--297d2268-f298-40a1-bec3-a1c836a69e38.yaml
+++ b/api/config/project/entryTypes/sourceSelector--297d2268-f298-40a1-bec3-a1c836a69e38.yaml
@@ -109,6 +109,18 @@ fieldLayouts:
             userCondition: null
             warning: null
             width: 50
+          -
+            elementCondition: null
+            fieldUid: 26b2b31f-6c46-4223-9050-e66a7445c9ec # Has Moving Source
+            instructions: 'Enable if the data set contains a moving source'
+            label: null
+            required: false
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 343e4269-9d32-49bc-b8ca-d9d6ebc0689e
+            userCondition: null
+            warning: null
+            width: 50
         name: Content
         uid: 897c373a-7e95-45dd-bcb4-8b0d2d51eced
         userCondition: null

--- a/api/config/project/fields/hasMovingSource--26b2b31f-6c46-4223-9050-e66a7445c9ec.yaml
+++ b/api/config/project/fields/hasMovingSource--26b2b31f-6c46-4223-9050-e66a7445c9ec.yaml
@@ -1,0 +1,14 @@
+columnSuffix: lzvlfdoi
+contentColumnType: boolean
+fieldGroup: a21a42b0-7211-4d77-9071-47a06960fef4 # Widgets
+handle: hasMovingSource
+instructions: null
+name: 'Has Moving Source'
+searchable: false
+settings:
+  default: false
+  offLabel: null
+  onLabel: null
+translationKeyFormat: null
+translationMethod: none
+type: craft\fields\Lightswitch

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1776890676
+dateModified: 1776990583
 elementSources:
   craft\elements\Entry:
     -
@@ -211,6 +211,7 @@ meta:
     24f2e959-23a9-4f1a-8394-0849fb85b85b: Precision # Precision
     25c0fbe7-5180-4842-bb9e-d530e9fb2042: Radius # Radius
     25eb3834-cb4a-46d7-823a-a135a16b9677: 'Save Point' # Save Point
+    26b2b31f-6c46-4223-9050-e66a7445c9ec: 'Has Moving Source' # Has Moving Source
     27af84b2-9ccb-416c-ae38-872fdca1f5c0: Layout # Layout
     28bf8eda-b10b-4aaa-98fd-d52d6c95ef57: Multiselect # Multiselect
     29f139cc-2d9b-4e10-afce-1e6a70105e2b: 'Multi-part Blocks' # Multi-part Blocks


### PR DESCRIPTION
# What it does
Resolves #195

This PR adds a new Lightswitch field to Craft with the handle `hasMovingSource`. This field is added to the `SourceSelector` widget settings; which the education team will use this to indicate whether or not the Source will be "static" or "moving".

This handle will be picked up in the client to determine which version of the `SourceSelector` widget should be rendered.

# Testing
This change can verified with the following GraphQL query:
_`exploding-stars-2` is a `Source Selector` entry slug in my environment. Replace this with a slug from your environment._

``` graphql
query VerifyHasMovingSource {
  entries(slug: "exploding-stars-2") {
    ... on widgets_sourceSelector_Entry {
      id
      hasMovingSource
      slug
    }
  }
}
```

The value of hasMovingSource should match the state of the switch in Craft (On = `true` / Off = `false`).