### PR TITLE
feat: add new default zoom field for use in controlling the starting zoom of orbital sim widgets

### DIFF
--- a/api/config/project/entryTypes/orbitalSim--6c962924-3a8a-4330-8938-b2ad19bde173.yaml
+++ b/api/config/project/entryTypes/orbitalSim--6c962924-3a8a-4330-8938-b2ad19bde173.yaml
@@ -33,6 +33,18 @@ fieldLayouts:
             width: 100
           -
             elementCondition: null
+            fieldUid: 060c8271-04e4-43af-9385-a7869562d048 # Default Zoom
+            instructions: 'Set this value to the desired starting zoom level for this Orbital Sim.'
+            label: null
+            required: true
+            tip: null
+            type: craft\fieldlayoutelements\CustomField
+            uid: 7ff31023-3e4c-42fd-ab6e-bb376aab9388
+            userCondition: null
+            warning: null
+            width: 100
+          -
+            elementCondition: null
             fieldUid: 1e81c616-5004-4ecd-b9bf-d6f1deafe256 # Contains Swappable Orbits
             instructions: null
             label: null

--- a/api/config/project/fields/defaultZoom--060c8271-04e4-43af-9385-a7869562d048.yaml
+++ b/api/config/project/fields/defaultZoom--060c8271-04e4-43af-9385-a7869562d048.yaml
@@ -1,0 +1,20 @@
+columnSuffix: pebbcvyy
+contentColumnType: 'decimal(12,2)'
+fieldGroup: 5599d188-862e-4717-b206-6aadd975c937 # Common
+handle: defaultZoom
+instructions: 'Set this value to the desired starting zoom level for this widget.'
+name: 'Default Zoom'
+searchable: false
+settings:
+  decimals: 2
+  defaultValue: 0.5
+  max: null
+  min: 0
+  prefix: null
+  previewCurrency: null
+  previewFormat: decimal
+  size: null
+  suffix: null
+translationKeyFormat: null
+translationMethod: none
+type: craft\fields\Number

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1778710650
+dateModified: 1780344141
 elementSources:
   craft\elements\Entry:
     -
@@ -229,6 +229,7 @@ meta:
     55ef91b0-a2ba-4935-8d49-9e3e1d3dcc91: 'Reference Entries' # Reference Entries
     56bdf2e8-b9b4-425d-a189-fc7b22f5d169: 'Display Table' # Display Table
     58dc56f1-d17a-424b-9aac-650a83f6b919: 'Table Cell' # Table Cell
+    060c8271-04e4-43af-9385-a7869562d048: 'Default Zoom' # Default Zoom
     61e0fe59-d439-429c-b783-2d71fe4c5d44: 'Y-axis Maximum' # Y-axis Maximum
     69b9ee9d-95c5-46a4-a1df-61f6c44a26ad: 'Show Sibling Nav' # Show Sibling Nav
     69cb131c-4118-487d-84be-d370e75627bd: Text # Text


### PR DESCRIPTION
Resolves #207

This field was added to address a need with the orbital sim widgets, but was named generally enough to be used in other widgets should the need ever arise.

It has been defined as a number field with two (2) decimal precision. In my earlier experimentation changes that small are not very noticeable.

Unfortunately, it's not possible to provide solid recommendations on what to set this value to in the helper text because it will depend on the needs of that widget and it's dataset.

To test:

1. Open an existing, or create a new Orbital Sim widget entry
2. Verify that you can see the required Default Zoom field in the Orbital Sim widget configuration
3. Set it to a value (if you set it to a precision higher than two decimal places you can see it round)
4. Run the following query in Craft's GraphQL explorer and verify that your value was saved

```
query MyVeryGoodDefaultZoomQuery ($widgetID: QueryArgument) {
  entries(type: "orbitalSim", id: [$widgetID]) {
    ... on widgets_orbitalSim_Entry {
      id
      defaultZoom
    }
  }
}
```
Note: you can grab the widgetID value from the URL in Craft when you are editing the widget's config.
