### PR TITLE
fix: update the instructions for the Alerts field

### DIFF
--- a/api/config/project/entryTypes/supernovaGalaxyObservations--5e789abf-cfef-4ed4-b795-a4dcfe4fd284.yaml
+++ b/api/config/project/entryTypes/supernovaGalaxyObservations--5e789abf-cfef-4ed4-b795-a4dcfe4fd284.yaml
@@ -124,7 +124,7 @@ fieldLayouts:
           -
             elementCondition: null
             fieldUid: a03e80f0-77ce-4b03-abf5-76a0deb264a9 # JSON
-            instructions: 'Alerts dataset'
+            instructions: "The \"id\" field for each alert must match its corresponding image's file name in the Canto album, minus the file extension.\r\nExample: an image named \"2003_QZ30_0.jpg\" gets an ID of \"2003_QZ30_0\"."
             label: Alerts
             required: true
             tip: null

--- a/api/config/project/project.yaml
+++ b/api/config/project/project.yaml
@@ -1,4 +1,4 @@
-dateModified: 1780344141
+dateModified: 1786994338
 elementSources:
   craft\elements\Entry:
     -


### PR DESCRIPTION
## What it does
Resolves #210 

This change provides instructions on matching dataset "id" field to the image's file name in the Canto album.

Instructions read:

> The "id" field for each alert must match its corresponding image's file name in the Canto album, minus the file extension.
Example: an image named "2003_QZ30_0.jpg" gets an ID of "2003_QZ30_0".

## Screenshots

Before:
<img width="1450" height="567" alt="image" src="https://github.com/user-attachments/assets/cf95f48b-c8a1-4f29-9a2f-cf8861d1d7b3" />

After:
<img width="1450" height="567" alt="image" src="https://github.com/user-attachments/assets/8bd149cc-a239-4832-81fe-9331a7d01896" />
